### PR TITLE
Don't autosave when changing focus or, e.g., q!

### DIFF
--- a/init/options.vim
+++ b/init/options.vim
@@ -55,10 +55,6 @@ set backupdir=~/.vim-tmp,~/tmp,/var/tmp,/tmp
 
 set hls                         " search with highlights by default
 
-" Write all writeable buffers when changing buffers or losing focus.
-set autowriteall                " Save when doing various buffer-switching things.
-autocmd BufLeave,FocusLost * silent! wall  " Save anytime we leave a buffer or MacVim loses focus.
-
 let g:sql_type_default="postgresql"
 
 " Turn off ri tooltips that don't work with Ruby 1.9 yet

--- a/init/options.vim
+++ b/init/options.vim
@@ -55,6 +55,9 @@ set backupdir=~/.vim-tmp,~/tmp,/var/tmp,/tmp
 
 set hls                         " search with highlights by default
 
+" Save anytime MacVim loses focus.
+autocmd FocusLost * silent! wall
+
 let g:sql_type_default="postgresql"
 
 " Turn off ri tooltips that don't work with Ruby 1.9 yet


### PR DESCRIPTION
I was messing around in a config file and screwed up. Didn't care to fix it in my edit buffer, and figured out what I wanted, so did q!. Vim silently (surprisingly) overwrote the file with my error in it.

This was frustrating. I don't mind additional functionality in vim config, because if I don't need it I can just ignore it. But changing default functionality (like q!) seems bad.